### PR TITLE
Feat primary abundance

### DIFF
--- a/src/xlranker/bio/pairs.py
+++ b/src/xlranker/bio/pairs.py
@@ -236,12 +236,8 @@ class ProteinPair(GroupedEntity):
         for abundance_key in self.a.abundances:
             a = self.a.abundances[abundance_key]
             b = self.b.abundances[abundance_key]
-            if safe_a_greater_or_equal_to_b(a, b):
-                ret_val[f"{abundance_key}_a"] = a
-                ret_val[f"{abundance_key}_b"] = b
-            else:  # make sure a is the larger value
-                ret_val[f"{abundance_key}_a"] = b
-                ret_val[f"{abundance_key}_b"] = a
+            ret_val[f"{abundance_key}_a"] = a
+            ret_val[f"{abundance_key}_b"] = b
         return ret_val
 
     def to_tsv(self) -> str:

--- a/src/xlranker/cli.py
+++ b/src/xlranker/cli.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from pathlib import Path
 import random
 from typing import Annotated, Any
 
@@ -14,6 +15,7 @@ from xlranker.config import DEFAULT_CONFIG
 from xlranker.lib import XLDataSet, setup_logging
 from xlranker.pipeline import run_full_pipeline
 from xlranker.util import set_seed
+from xlranker.util.readers import base_name
 from xlranker.util.mapping import FastaType, PeptideMapper
 
 app = cyclopts.App()
@@ -106,6 +108,14 @@ def init(
         only_directories=True,
         validate=is_folder,
     ).ask()
+    globs = [str(p) for p in list(Path(omic_data).glob("*"))]
+    primary_column = None
+    if len(globs) > 0:
+        selected_file = questionary.select(
+            "Which file is the primary abundance value?", choices=globs
+        ).ask()
+        primary_column = base_name(str(selected_file))
+
     mapping_table = questionary.select(
         "What mapping table will you use?",
         choices=[
@@ -143,6 +153,8 @@ def init(
         "is_fasta": is_fasta,
         "only_human": only_human,
     }
+    if primary_column is not None:
+        output_config["primary_column"] = primary_column
     if mapping_table_path is not None:
         output_config["mapping_table"] = mapping_table_path
         if is_fasta:

--- a/src/xlranker/config.py
+++ b/src/xlranker/config.py
@@ -12,6 +12,7 @@ DEFAULT_CONFIG = {
     "fasta_type": "UNIPROT",
     "only_human": True,
     "intra_in_training": False,
+    "primary_column": None,
     "advanced": {
         "intra_in_training": False,  # allow intra in training data
     },
@@ -64,6 +65,7 @@ class Config:
         output (str): Default to "xlranker_output/". Directory where output files are saved.
         additional_null_values (list[str]): Default to []. Additional null values to consider when reading data files.
         advanced (AdvancedConfig): Advanced configuration options
+        primary_column (str | None): Column name of which omic file should be the representative. If None, default to the first file alphabetically.
         mapping (MappingConfig): Configuration related to peptide sequence mapping.
 
     """
@@ -73,6 +75,9 @@ class Config:
     reduce_fasta: bool = False  # Reduce FASTA file by only keeping the largest sequence
     human_only: bool = True  # Is all data human only?
     output: str = "xlranker_output/"  # output directory
+    primary_column: str | None = (
+        None  # Which omic file should be the representative omic set for ordering
+    )
     additional_null_values: list[str] = field(
         default_factory=list
     )  # additional null values to consider when reading data files

--- a/src/xlranker/lib.py
+++ b/src/xlranker/lib.py
@@ -10,6 +10,7 @@ from xlranker.util import get_abundance, get_pair_id
 from xlranker.util.mapping import FastaType, PeptideMapper, convert_str_to_fasta_type
 from xlranker.util.readers import read_data_folder, read_network_file
 
+from xlranker.config import config as xlr_config
 from .bio import Protein
 from .bio.pairs import PeptidePair, ProteinPair
 from .status import PrioritizationStatus
@@ -109,7 +110,9 @@ class XLDataSet:
                 abundances[omic_file] = get_abundance(
                     self.omic_data[omic_file], protein
                 )
-            self.proteins[protein] = Protein(protein, protein, abundances)
+            self.proteins[protein] = Protein(
+                protein, protein, abundances, xlr_config.primary_column
+            )
         remove_pairs = []
         for (
             peptide_pair_key


### PR DESCRIPTION
This PR improves on the ordering of the abundances given the machine learning model for cases where there are multiple omic data files.

## Example

Imagine protein X and protein Y had the following omic data sets

| Protein | Protein Abundance | RNA Abundance |
|:--------:|:--------:|:--------:|
| X | 20.1 | 9.2 |
| Y | 14.3 |11.8 |

The model would have four features, Prot_A, RNA_A, Prot_B, RNA_B. To make the assignment of A and B meaningful, xlranker assigns A to be the higher value. This is good for single datasets. However, the sorting when there are multiple datasets is done individually. So in the above example, Prot_A would correspond to Protein X, but RNA_A would be Protein Y.

This PR addresses this by adding a `primary_column` key to the config file which corresponds to the name of the file (without folder or file extensions) that should be used as the abundance value used to sort all columns. This is typically protein, so if that was set as the primary column, X would be Prot_A and RNA_A.