### PR TITLE
Feature: Linkage information

### DIFF
--- a/src/xlranker/bio/pairs.py
+++ b/src/xlranker/bio/pairs.py
@@ -207,6 +207,15 @@ class ProteinPair(GroupedEntity):
         """Set this pair to be selected."""
         self.is_selected = True
 
+    def __str__(self) -> str:
+        """Get string representation of the protein pair including linkages.
+
+        Returns:
+            str: pair ID with linkages if present
+
+        """
+        return get_pair_id_from_str(str(self.a), str(self.b))
+
     def __eq__(self, value: "object | ProteinPair") -> bool:
         """Checks if ProteinPairs are equivalent, without caring for order.
 
@@ -296,6 +305,15 @@ class PeptidePair(GroupedEntity):
         self.a = peptide_a
         self.b = peptide_b
         self.pair_id = get_pair_id(peptide_a, peptide_b)
+
+    def __str__(self) -> str:
+        """Get string representation of the peptide pair.
+
+        Returns:
+            str: the pair ID
+
+        """
+        return self.pair_id
 
     def __hash__(self) -> int:
         """Get hash of this PeptidePair.

--- a/src/xlranker/bio/pairs.py
+++ b/src/xlranker/bio/pairs.py
@@ -3,7 +3,7 @@
 from xlranker.bio.peptide import Peptide
 from xlranker.bio.protein import Protein, sort_proteins
 from xlranker.status import PrioritizationStatus, ReportStatus
-from xlranker.util import get_pair_id
+from xlranker.util import get_pair_id, get_pair_id_from_str
 
 
 class GroupedEntity:

--- a/src/xlranker/bio/peptide.py
+++ b/src/xlranker/bio/peptide.py
@@ -35,7 +35,8 @@ class Peptide:
 
         """
         self.sequence = sequence
-        self.linkage = linkage
+        if linkage is not None and linkage <= len(self.sequence):
+            self.linkage = linkage
         self.mapped_proteins = mapped_proteins
 
     def __str__(self) -> str:

--- a/src/xlranker/bio/peptide.py
+++ b/src/xlranker/bio/peptide.py
@@ -14,15 +14,21 @@ class Peptide:
     Attributes:
         sequence (str): Peptide sequence from peptide network
         mapped_proteins (list[str]): list of all proteins mapping to sequence
+        protein_linkages (dict[str, str]): mapping of protein name to linkage location
 
     """
 
     sequence: str
     mapped_proteins: list[str]
     linkage: int | None
+    protein_linkages: dict[str, str]
 
     def __init__(
-        self, sequence: str, linkage: int | None = None, mapped_proteins: list[str] = []
+        self,
+        sequence: str,
+        linkage: int | None = None,
+        mapped_proteins: list[str] = [],
+        protein_linkages: dict[str, str] = {},
     ):
         """Initialize the Peptide object with a sequence and mapped proteins.
 
@@ -32,12 +38,16 @@ class Peptide:
                 on the amino acid sequence. Defaults to None.
             mapped_proteins (list[str], optional): list of protein names this sequence
                 maps to. Defaults to [].
+            protein_linkages (dict[str, str], optional): mapping of protein name to
+                linkage location. Defaults to {}.
 
         """
         self.sequence = sequence
+        self.linkage = None
         if linkage is not None and linkage <= len(self.sequence):
             self.linkage = linkage
         self.mapped_proteins = mapped_proteins
+        self.protein_linkages = protein_linkages
 
     def __str__(self) -> str:
         """Get the string representation of this peptide.

--- a/src/xlranker/bio/peptide.py
+++ b/src/xlranker/bio/peptide.py
@@ -19,24 +19,34 @@ class Peptide:
 
     sequence: str
     mapped_proteins: list[str]
+    linkage: int | None
 
-    def __init__(self, sequence: str, mapped_proteins: list[str] = []):
+    def __init__(
+        self, sequence: str, linkage: int | None = None, mapped_proteins: list[str] = []
+    ):
         """Initialize the Peptide object with a sequence and mapped proteins.
 
         Args:
             sequence (str): amino acid sequence
+            linkage (int | None): Optional 1-based index of the linkage
+                on the amino acid sequence. Defaults to None.
             mapped_proteins (list[str], optional): list of protein names this sequence
                 maps to. Defaults to [].
 
         """
         self.sequence = sequence
+        self.linkage = linkage
         self.mapped_proteins = mapped_proteins
 
     def __str__(self) -> str:
         """Get the string representation of this peptide.
 
+        If linkage is present, it is added to string and separated by ':'.
+
         Returns:
             str: the amino acid sequence of this peptide.
 
         """
+        if self.linkage is not None:
+            return f"{self.sequence}:{self.linkage}"
         return self.sequence

--- a/src/xlranker/bio/protein.py
+++ b/src/xlranker/bio/protein.py
@@ -130,6 +130,7 @@ class Protein:
     abundances: dict[str, float | None]
     main_column: str
     unique_identifier: str
+    linkage: int | None
 
     def __init__(
         self,

--- a/src/xlranker/bio/protein.py
+++ b/src/xlranker/bio/protein.py
@@ -170,7 +170,8 @@ class Protein:
         Args:
             link (str): linkage location
         """
-        self.linkages.append(link)
+        if link not in self.linkages:
+            self.linkages.append(link)
 
     def __str__(self) -> str:
         """Get the string representation of this protein.
@@ -181,7 +182,7 @@ class Protein:
             str: the name of this protein.
 
         """
-        if self.linkages is not None:
+        if len(self.linkages) > 0:
             return f"{self.name}:{','.join(self.linkages)}"
         return self.name
 

--- a/src/xlranker/bio/protein.py
+++ b/src/xlranker/bio/protein.py
@@ -123,6 +123,7 @@ class Protein:
             abundance for the protein. Used for sorting the
         proteins.
         protein_name (str): name of the protein specific to the isoform level.
+        linkages (list[str]): linkages observed
 
     """
 
@@ -130,7 +131,7 @@ class Protein:
     abundances: dict[str, float | None]
     main_column: str
     unique_identifier: str
-    linkage: int | None
+    linkages: list[str]
 
     def __init__(
         self,
@@ -154,6 +155,7 @@ class Protein:
         self.name = name
         self.unique_identifier = unique_identifier
         self.abundances = abundances
+        self.linkages = []
         if main_column is None:
             if len(abundances) == 0:
                 self.main_column = ""
@@ -161,6 +163,27 @@ class Protein:
                 self.main_column = next(iter(abundances))
         else:
             self.main_column = main_column
+
+    def add_linkage(self, link: str) -> None:
+        """Add linkage to protein.
+
+        Args:
+            link (str): linkage location
+        """
+        self.linkages.append(link)
+
+    def __str__(self) -> str:
+        """Get the string representation of this protein.
+
+        If linkage is present, it is added to string and separated by ':'.
+
+        Returns:
+            str: the name of this protein.
+
+        """
+        if self.linkages is not None:
+            return f"{self.name}:{','.join(self.linkages)}"
+        return self.name
 
     def __eq__(self, value: object) -> bool:
         """Determine if object is equal to another.

--- a/src/xlranker/cli.py
+++ b/src/xlranker/cli.py
@@ -141,9 +141,11 @@ def init(
             ).ask()
             mapping_table_path = questionary.path(
                 "Path to fasta file:",
-                validate=lambda x: True
-                if x.lower().endswith(".fa") or x.lower().endswith(".fasta")
-                else "Please input a FASTA file (.fasta or .fa)",
+                validate=lambda x: (
+                    True
+                    if x.lower().endswith(".fa") or x.lower().endswith(".fasta")
+                    else "Please input a FASTA file (.fasta or .fa)"
+                ),
             ).ask()
             if fasta_type == "GENCODE":
                 print(
@@ -195,11 +197,13 @@ def init(
     else:
         output_path: str = questionary.path(
             "Output file for config (JSON or YAML format):",
-            validate=lambda x: True
-            if x.lower().endswith(".json")
-            or x.lower().endswith(".yaml")
-            or x.lower().endswith(".yml")
-            else "File must end with .json, .yaml, or .yml",
+            validate=lambda x: (
+                True
+                if x.lower().endswith(".json")
+                or x.lower().endswith(".yaml")
+                or x.lower().endswith(".yml")
+                else "File must end with .json, .yaml, or .yml"
+            ),
         ).ask()
 
     save_config(output_path, config_to_dict(new_config))  # type: ignore

--- a/src/xlranker/lib.py
+++ b/src/xlranker/lib.py
@@ -368,8 +368,10 @@ def write_pair_to_network(pairs: list[ProteinPair], output_file: str) -> None:
         w.write("\n".join(network_strings) + "\n")
 
 
-def write_pair_to_network_with_linkages(pairs: list[ProteinPair], output_file: str) -> None:
-    """Write list of protein pairs to a TSV file with linkages in 4 columns.
+def write_pair_to_network_with_linkages(
+    pairs: list[ProteinPair], output_file: str
+) -> None:
+    r"""Write list of protein pairs to a TSV file with linkages in 4 columns.
 
     Format: ProteinA \\t LinkagesA \\t ProteinB \\t LinkagesB.
 

--- a/src/xlranker/lib.py
+++ b/src/xlranker/lib.py
@@ -147,8 +147,16 @@ class XLDataSet:
             else:
                 for protein_a_name in peptide_pair.a.mapped_proteins:
                     protein_a = self.proteins[protein_a_name]
+                    if protein_a_name in peptide_pair.a.protein_linkages:
+                        protein_a.add_linkage(
+                            peptide_pair.a.protein_linkages[protein_a_name]
+                        )
                     for protein_b_name in peptide_pair.b.mapped_proteins:
                         protein_b = self.proteins[protein_b_name]
+                        if protein_b_name in peptide_pair.b.protein_linkages:
+                            protein_b.add_linkage(
+                                peptide_pair.b.protein_linkages[protein_b_name]
+                            )
                         protein_pair_id = get_pair_id(protein_a, protein_b)
                         if protein_pair_id not in self.protein_pairs:
                             new_pair = ProteinPair(protein_a, protein_b)
@@ -259,17 +267,59 @@ class XLDataSet:
             )
         else:
             mapper = custom_mapper
-        # mapping_results = mapper.map_sequences(sorted(list(peptide_sequences)))
-        mapping_results = mapper.map_fasta_with_loc(sorted(list(peptide_sequences)))
+        if is_fasta:
+            mapping_results = mapper.map_fasta_with_loc(sorted(list(peptide_sequences)))
+        else:
+            mapping_results = mapper.map_sequences(sorted(list(peptide_sequences)))
+
         for peptide_pair in sorted(
             network.values(), key=lambda p: p.a.sequence + p.b.sequence
         ):
-            peptide_pair.a.mapped_proteins = mapping_results.peptide_to_protein[
-                peptide_pair.a.sequence
-            ]
-            peptide_pair.b.mapped_proteins = mapping_results.peptide_to_protein[
-                peptide_pair.b.sequence
-            ]
+            # Process Peptide A
+            matches_a = mapping_results.peptide_to_protein[peptide_pair.a.sequence]
+            if is_fasta:
+                peptide_pair.a.mapped_proteins = [m.protein_name for m in matches_a]
+                if (
+                    peptide_pair.a.linkage is not None
+                    and mapping_results.protein_sequences is not None
+                ):
+                    for match in matches_a:
+                        protein_seq = mapping_results.protein_sequences[
+                            match.protein_name
+                        ]
+                        protein_link_index = (
+                            match.start_index + peptide_pair.a.linkage - 1
+                        )
+                        if protein_link_index <= len(protein_seq):
+                            residue = protein_seq[protein_link_index - 1]
+                            peptide_pair.a.protein_linkages[match.protein_name] = (
+                                f"{residue}{protein_link_index}"
+                            )
+            else:
+                peptide_pair.a.mapped_proteins = matches_a
+
+            # Process Peptide B
+            matches_b = mapping_results.peptide_to_protein[peptide_pair.b.sequence]
+            if is_fasta:
+                peptide_pair.b.mapped_proteins = [m.protein_name for m in matches_b]
+                if (
+                    peptide_pair.b.linkage is not None
+                    and mapping_results.protein_sequences is not None
+                ):
+                    for match in matches_b:
+                        protein_seq = mapping_results.protein_sequences[
+                            match.protein_name
+                        ]
+                        protein_link_index = (
+                            match.start_index + peptide_pair.b.linkage - 1
+                        )
+                        if protein_link_index <= len(protein_seq):
+                            residue = protein_seq[protein_link_index - 1]
+                            peptide_pair.b.protein_linkages[match.protein_name] = (
+                                f"{residue}{protein_link_index}"
+                            )
+            else:
+                peptide_pair.b.mapped_proteins = matches_b
         return cls(network, omic_data)
 
 
@@ -314,5 +364,26 @@ def write_pair_to_network(pairs: list[ProteinPair], output_file: str) -> None:
     for pair in sorted(pairs, key=lambda x: x.pair_id):
         splits = pair.pair_id.split(xlr_config.advanced.pair_separator)
         network_strings.append(f"{splits[0]}\t{splits[1]}")
+    with open(output_file, "w") as w:
+        w.write("\n".join(network_strings) + "\n")
+
+
+def write_pair_to_network_with_linkages(pairs: list[ProteinPair], output_file: str) -> None:
+    """Write list of protein pairs to a TSV file with linkages in 4 columns.
+
+    Format: ProteinA \\t LinkagesA \\t ProteinB \\t LinkagesB.
+
+    Args:
+        pairs (list[ProteinPair]): list of protein pairs to save to file.
+        output_file (str): path to write TSV file. Full path must be accessible.
+
+    """
+    network_strings = []
+    for pair in sorted(pairs, key=lambda x: x.pair_id):
+        linkages_a = ",".join(pair.a.linkages) if pair.a.linkages else ""
+        linkages_b = ",".join(pair.b.linkages) if pair.b.linkages else ""
+        network_strings.append(
+            f"{pair.a.name}\t{linkages_a}\t{pair.b.name}\t{linkages_b}"
+        )
     with open(output_file, "w") as w:
         w.write("\n".join(network_strings) + "\n")

--- a/src/xlranker/lib.py
+++ b/src/xlranker/lib.py
@@ -259,7 +259,8 @@ class XLDataSet:
             )
         else:
             mapper = custom_mapper
-        mapping_results = mapper.map_sequences(sorted(list(peptide_sequences)))
+        # mapping_results = mapper.map_sequences(sorted(list(peptide_sequences)))
+        mapping_results = mapper.map_fasta_with_loc(sorted(list(peptide_sequences)))
         for peptide_pair in sorted(
             network.values(), key=lambda p: p.a.sequence + p.b.sequence
         ):

--- a/src/xlranker/lib.py
+++ b/src/xlranker/lib.py
@@ -239,14 +239,14 @@ class XLDataSet:
         """
         split_by = "|" if split_by is None else split_by
         split_index = 6 if split_index is None else split_index
-        network = read_network_file(network_path)
+        (network, has_linkages) = read_network_file(network_path)
         omic_data: dict[str, pl.DataFrame] = read_data_folder(
             omics_data_folder, omic_data_files
         )
         peptide_sequences = set()
-        for group in network.values():
-            peptide_sequences.add(group.a.sequence)
-            peptide_sequences.add(group.b.sequence)
+        for peptide_pair in network.values():
+            peptide_sequences.add(peptide_pair.a.sequence)
+            peptide_sequences.add(peptide_pair.b.sequence)
         if isinstance(fasta_type, str):
             fasta_type = convert_str_to_fasta_type(fasta_type)
         if custom_mapper is None:
@@ -260,14 +260,14 @@ class XLDataSet:
         else:
             mapper = custom_mapper
         mapping_results = mapper.map_sequences(sorted(list(peptide_sequences)))
-        for group in sorted(
+        for peptide_pair in sorted(
             network.values(), key=lambda p: p.a.sequence + p.b.sequence
         ):
-            group.a.mapped_proteins = mapping_results.peptide_to_protein[
-                group.a.sequence
+            peptide_pair.a.mapped_proteins = mapping_results.peptide_to_protein[
+                peptide_pair.a.sequence
             ]
-            group.b.mapped_proteins = mapping_results.peptide_to_protein[
-                group.b.sequence
+            peptide_pair.b.mapped_proteins = mapping_results.peptide_to_protein[
+                peptide_pair.b.sequence
             ]
         return cls(network, omic_data)
 

--- a/src/xlranker/report.py
+++ b/src/xlranker/report.py
@@ -134,7 +134,7 @@ def mapping_peptide_pair_to_protein_pairs(
 def mapping_peptide_pair_to_protein_pairs_with_linkages(
     data_set: XLDataSet, output_path: str | None = None
 ) -> None:
-    """Write mapping table with peptide pairs and their corresponding protein pairs with linkages.
+    """Write mapping table with peptide pairs and their corresponding protein pairs.
 
     Args:
         data_set (XLDataSet): XL data set to create mapping table from
@@ -198,7 +198,7 @@ def mapping_peptide_to_protein(
 def mapping_peptide_to_protein_with_linkages(
     data_set: XLDataSet, output_path: str | None = None
 ) -> None:
-    """Write mapping table that shows a peptide and its corresponding mapped proteins with linkages.
+    """Write mapping table that shows a peptide and its corresponding mapped proteins.
 
     Args:
         data_set (XLDataSet): XL data set to create mapping table from
@@ -248,7 +248,7 @@ def mapping_peptide_pair_to_best_protein_pair(
     data = []
     for peptide_pair_id in sorted(data_set.peptide_pairs.keys()):
         peptide_pair = data_set.peptide_pairs[peptide_pair_id]
-        
+
         best_prot_pair = None
         for prot_pair_id in peptide_pair.connections:
             prot_pair = data_set.protein_pairs[prot_pair_id]
@@ -265,7 +265,7 @@ def mapping_peptide_pair_to_best_protein_pair(
             data.append(f"{peptide_pair_id}\t{best_prot_pair.pair_id}")
         else:
             data.append(f"{peptide_pair_id}\t")
-            
+
     with open(output_path, "w") as w:
         w.write("\n".join(data))
 

--- a/src/xlranker/report.py
+++ b/src/xlranker/report.py
@@ -7,7 +7,11 @@ from pydantic import BaseModel
 
 from xlranker.bio.pairs import ProteinPair
 from xlranker.config import config
-from xlranker.lib import XLDataSet, write_pair_to_network
+from xlranker.lib import (
+    XLDataSet,
+    write_pair_to_network,
+    write_pair_to_network_with_linkages,
+)
 from xlranker.status import ReportStatus
 from xlranker.util import get_pair_id_from_str
 
@@ -44,6 +48,21 @@ def make_report(
     write_pair_to_network(valid_pairs, str(output_path))
 
 
+def make_report_with_linkages(
+    pairs: list[ProteinPair], status: ReportStatus, output_path: Path
+) -> None:
+    """Write network of protein pairs with linkages.
+
+    Args:
+        pairs (list[ProteinPair]): list of all protein pairs
+        status (ReportStatus): Minimum status to accept.
+        output_path (Path): output path to save pair to
+
+    """
+    valid_pairs = [pair for pair in pairs if pair.report_status <= status]
+    write_pair_to_network_with_linkages(valid_pairs, str(output_path))
+
+
 def make_all_reports(pairs: list[ProteinPair]) -> None:
     """Write reports for all status levels to the output_folder specified in the config.
 
@@ -58,6 +77,19 @@ def make_all_reports(pairs: list[ProteinPair]) -> None:
     make_report(pairs, ReportStatus.EXPANDED, output_folder / "expanded.tsv")
     make_report(pairs, ReportStatus.ALL, output_folder / "all.tsv")
 
+    make_report_with_linkages(
+        pairs, ReportStatus.UNIQUE, output_folder / "unique_with_linkages.tsv"
+    )
+    make_report_with_linkages(
+        pairs, ReportStatus.MINIMAL, output_folder / "minimal_with_linkages.tsv"
+    )
+    make_report_with_linkages(
+        pairs, ReportStatus.EXPANDED, output_folder / "expanded_with_linkages.tsv"
+    )
+    make_report_with_linkages(
+        pairs, ReportStatus.ALL, output_folder / "all_with_linkages.tsv"
+    )
+
 
 def make_mapping_tables(data_set: XLDataSet) -> None:
     """Make all mapping tables.
@@ -68,7 +100,10 @@ def make_mapping_tables(data_set: XLDataSet) -> None:
         data_set (XLDataSet): XL data set to create mapping table from
     """
     mapping_peptide_pair_to_protein_pairs(data_set)
+    mapping_peptide_pair_to_protein_pairs_with_linkages(data_set)
     mapping_peptide_to_protein(data_set)
+    mapping_peptide_to_protein_with_linkages(data_set)
+    mapping_peptide_pair_to_best_protein_pair(data_set)
 
 
 def mapping_peptide_pair_to_protein_pairs(
@@ -91,6 +126,33 @@ def mapping_peptide_pair_to_protein_pairs(
         row = [peptide_pair]
         for protein_pair in data_set.peptide_pairs[peptide_pair].connections:
             row.append(protein_pair)
+        data.append("\t".join(row))
+    with open(output_path, "w") as w:
+        w.write("\n".join(data))
+
+
+def mapping_peptide_pair_to_protein_pairs_with_linkages(
+    data_set: XLDataSet, output_path: str | None = None
+) -> None:
+    """Write mapping table with peptide pairs and their corresponding protein pairs with linkages.
+
+    Args:
+        data_set (XLDataSet): XL data set to create mapping table from
+        output_path (str | None, optional): Output path, if None will use default path.
+            Defaults to None.
+
+    """
+    if output_path is None:
+        output_folder = Path(config.output).joinpath("mapping")
+        output_folder.mkdir(exist_ok=True)
+        output_path = str(output_folder / "peptide_to_protein_pair_with_linkages.tsv")
+    data = []
+    for peptide_pair_id in sorted(data_set.peptide_pairs.keys()):
+        peptide_pair = data_set.peptide_pairs[peptide_pair_id]
+        row = [str(peptide_pair)]
+        for prot_pair_id in sorted(peptide_pair.connections):
+            prot_pair = data_set.protein_pairs[prot_pair_id]
+            row.append(str(prot_pair))
         data.append("\t".join(row))
     with open(output_path, "w") as w:
         w.write("\n".join(data))
@@ -129,6 +191,81 @@ def mapping_peptide_to_protein(
             for prot in peptide_pair.b.mapped_proteins:
                 row.append(prot)
             data.append("\t".join(row))
+    with open(output_path, "w") as w:
+        w.write("\n".join(data))
+
+
+def mapping_peptide_to_protein_with_linkages(
+    data_set: XLDataSet, output_path: str | None = None
+) -> None:
+    """Write mapping table that shows a peptide and its corresponding mapped proteins with linkages.
+
+    Args:
+        data_set (XLDataSet): XL data set to create mapping table from
+        output_path (str | None, optional): Output path, if None will use default path.
+            Defaults to None.
+
+    """
+    if output_path is None:
+        output_folder = Path(config.output).joinpath("mapping")
+        output_folder.mkdir(exist_ok=True)
+        output_path = str(output_folder / "peptide_to_protein_with_linkages.tsv")
+    data = []
+    uniq_peptides = set()
+    for peptide_pair in sorted(
+        data_set.peptide_pairs.values(),
+        key=lambda p: p.a.sequence + p.b.sequence,
+    ):
+        for peptide in (peptide_pair.a, peptide_pair.b):
+            pep_str = str(peptide)
+            if pep_str not in uniq_peptides:
+                uniq_peptides.add(pep_str)
+                row = [pep_str]
+                for prot in peptide.mapped_proteins:
+                    linkage = peptide.protein_linkages.get(prot, "")
+                    prot_str = f"{prot}:{linkage}" if linkage else prot
+                    row.append(prot_str)
+                data.append("\t".join(row))
+    with open(output_path, "w") as w:
+        w.write("\n".join(data))
+
+
+def mapping_peptide_pair_to_best_protein_pair(
+    data_set: XLDataSet, output_path: str | None = None
+) -> None:
+    """Write mapping table showing the best selected protein pair for each peptide pair.
+
+    Args:
+        data_set (XLDataSet): XL data set to create mapping table from
+        output_path (str | None, optional): Output path, if None will use default path.
+            Defaults to None.
+
+    """
+    if output_path is None:
+        output_folder = Path(config.output).joinpath("mapping")
+        output_folder.mkdir(exist_ok=True)
+        output_path = str(output_folder / "peptide_to_best_protein_pair.tsv")
+    data = []
+    for peptide_pair_id in sorted(data_set.peptide_pairs.keys()):
+        peptide_pair = data_set.peptide_pairs[peptide_pair_id]
+        
+        best_prot_pair = None
+        for prot_pair_id in peptide_pair.connections:
+            prot_pair = data_set.protein_pairs[prot_pair_id]
+            if best_prot_pair is None:
+                best_prot_pair = prot_pair
+            else:
+                if prot_pair.report_status < best_prot_pair.report_status:
+                    best_prot_pair = prot_pair
+                elif prot_pair.report_status == best_prot_pair.report_status:
+                    if prot_pair.score > best_prot_pair.score:
+                        best_prot_pair = prot_pair
+
+        if best_prot_pair is not None:
+            data.append(f"{peptide_pair_id}\t{best_prot_pair.pair_id}")
+        else:
+            data.append(f"{peptide_pair_id}\t")
+            
     with open(output_path, "w") as w:
         w.write("\n".join(data))
 

--- a/src/xlranker/util/__init__.py
+++ b/src/xlranker/util/__init__.py
@@ -58,16 +58,15 @@ def get_pair_id(a: Protein | Peptide, b: Protein | Peptide) -> str:
            config.advanced.pair_separator (default '+').
 
     """
-    name_a = ""
-    name_b = ""
-    if isinstance(a, Protein):
+    if isinstance(a, Peptide):
+        name_a = str(a)
+    else:
         name_a = a.name
+
+    if isinstance(b, Peptide):
+        name_b = str(b)
     else:
-        name_a = a.sequence
-    if isinstance(b, Protein):
         name_b = b.name
-    else:
-        name_b = b.sequence
     return get_pair_id_from_str(name_a, name_b)
 
 

--- a/src/xlranker/util/mapping.py
+++ b/src/xlranker/util/mapping.py
@@ -102,11 +102,32 @@ class SequenceMatch:
     Attributes:
         unique_identifier (str): Isoform-specific identifier
         protein_name (str): Protein-level name from fasta file. Typically in Gene Symbol
+        match_location (int): Location in the FASTA sequence where the peptide starts.
+            For FASTA sequence ABCDEF, CDE would be a match loc of 3.
 
     """
 
     unique_identifier: str
     protein_name: str
+    match_location: int
+
+
+@dataclass
+class MappingResultWithLoc:
+    """Results from mapping peptide sequences to proteins.
+
+    Args:
+        peptide_to_protein (dict[str, list[str]]): Dictionary where keys are peptide
+            sequences and values are the list of proteins that map to that sequence.
+        protein_sequences (dict[str, str] | None): Optional dictionary where keys are
+            protein names and values are those proteins sequence.
+            Used for linkage location.
+            None if sequence not available (i.e. mapping table)
+
+    """
+
+    peptide_to_protein: dict[str, list[SequenceMatch]]
+    protein_sequences: dict[str, str] | None
 
 
 @dataclass
@@ -389,6 +410,73 @@ class PeptideMapper:
             final_matches[key] = list(matches[key])
         return MappingResult(
             peptide_to_protein=final_matches,
+            protein_sequences=protein_sequences,
+        )
+
+    def map_fasta_with_reduction_with_loc(
+        self, sequences: list[str], automaton: ahocorasick.Automaton
+    ) -> MappingResultWithLoc:
+        """Maps the provided sequences to proteins with a reduced FASTA file.
+
+        Keeps only the longest sequence is kept for duplicated proteins.
+
+        Duplicate proteins are proteins that share the same gene symbol identification.
+
+        Args:
+            sequences (list[str]): list of peptide sequences to map.
+            automaton (ahocorasick.Automaton): An automaton built from the peptides.
+
+        Returns:
+            MappingResult: Result of the mapping.
+
+        """
+        logger.debug("Mapping FASTA file with reduction")
+        matches: dict[str, list[SequenceMatch]] = {}
+        for seq in sequences:
+            matches[seq] = []
+        logger.info(f"Mapping {len(sequences)} peptide sequences")
+
+        # First, build a mapping from gene symbol to its longest protein sequence
+        gene_to_longest_protein = {}
+        gene_to_longest_length: dict[str, int] = {}
+
+        for record in SeqIO.parse(self.mapping_table_path, "fasta"):
+            gene_symbol = extract_gene_symbol(
+                record.description,
+                self.fasta_type,
+                split_by=self.split_by,
+                split_index=self.split_index,
+            )
+            seq_str = str(record.seq)
+            seq_len = len(seq_str)
+            if (
+                gene_symbol not in gene_to_longest_length
+                or seq_len > gene_to_longest_length[gene_symbol]
+            ):
+                gene_to_longest_length[gene_symbol] = seq_len
+                gene_to_longest_protein[gene_symbol] = seq_str
+
+        protein_sequences: dict[str, str] = {}
+
+        # Now, map sequences only if they are present in the longest protein sequence
+        # for that gene
+        for gene_symbol, protein_seq in gene_to_longest_protein.items():
+            mapped = False
+            for end_index, sequence in automaton.iter(str(protein_seq)):
+                start_index = (
+                    end_index - len(sequence) + 2
+                )  # TODO: Check if 2 is correct
+                seq_match = SequenceMatch(
+                    unique_identifier=gene_symbol,
+                    protein_name=gene_symbol,
+                    match_location=start_index,
+                )
+                matches[sequence].append(seq_match)
+                mapped = True
+            if mapped:
+                protein_sequences[gene_symbol] = protein_seq
+        return MappingResultWithLoc(
+            peptide_to_protein=matches,
             protein_sequences=protein_sequences,
         )
 

--- a/src/xlranker/util/mapping.py
+++ b/src/xlranker/util/mapping.py
@@ -109,7 +109,7 @@ class SequenceMatch:
 
     unique_identifier: str
     protein_name: str
-    match_location: int
+    match_location: str
 
 
 @dataclass
@@ -316,6 +316,19 @@ class PeptideMapper:
             return self.map_fasta_with_reduction(sequences, automaton)
         return self.map_fasta_no_reduction(sequences, automaton)
 
+    def map_fasta_with_loc(self, sequences: list[str]) -> MappingResultWithLoc:
+        """Map the provided sequences to proteins using a FASTA file.
+
+        Args:
+            sequences (list[str]): list of peptide sequences to map.
+
+        Returns:
+            MappingResult: Result of the mapping.
+
+        """
+        automaton = build_automaton(sequences)
+        return self.map_fasta_with_reduction_with_loc(sequences, automaton)
+
     def map_fasta_no_reduction(
         self, sequences: list[str], automaton: ahocorasick.Automaton
     ) -> MappingResult:
@@ -466,10 +479,11 @@ class PeptideMapper:
                 start_index = (
                     end_index - len(sequence) + 2
                 )  # TODO: Check if 2 is correct
+                match_location = f"{sequence[start_index - 1]}{start_index}"
                 seq_match = SequenceMatch(
                     unique_identifier=gene_symbol,
                     protein_name=gene_symbol,
-                    match_location=start_index,
+                    match_location=match_location,
                 )
                 matches[sequence].append(seq_match)
                 mapped = True

--- a/src/xlranker/util/mapping.py
+++ b/src/xlranker/util/mapping.py
@@ -102,13 +102,14 @@ class SequenceMatch:
     Attributes:
         unique_identifier (str): Isoform-specific identifier
         protein_name (str): Protein-level name from fasta file. Typically in Gene Symbol
-        match_location (int): Location in the FASTA sequence where the peptide starts.
-            For FASTA sequence ABCDEF, CDE would be a match loc of 3.
+        start_index (int): 1-based start index of the match in the protein sequence.
+        match_location (str): Location string (e.g., "M1") where the peptide starts.
 
     """
 
     unique_identifier: str
     protein_name: str
+    start_index: int
     match_location: str
 
 
@@ -117,8 +118,8 @@ class MappingResultWithLoc:
     """Results from mapping peptide sequences to proteins.
 
     Args:
-        peptide_to_protein (dict[str, list[str]]): Dictionary where keys are peptide
-            sequences and values are the list of proteins that map to that sequence.
+        peptide_to_protein (dict[str, list[SequenceMatch]]): Dictionary where keys are
+            peptide sequences and values are the list of SequenceMatch objects.
         protein_sequences (dict[str, str] | None): Optional dictionary where keys are
             protein names and values are those proteins sequence.
             Used for linkage location.
@@ -476,13 +477,12 @@ class PeptideMapper:
         for gene_symbol, protein_seq in gene_to_longest_protein.items():
             mapped = False
             for end_index, sequence in automaton.iter(str(protein_seq)):
-                start_index = (
-                    end_index - len(sequence) + 2
-                )  # TODO: Check if 2 is correct
-                match_location = f"{sequence[start_index - 1]}{start_index}"
+                start_index = end_index - len(sequence) + 2
+                match_location = f"{sequence[0]}{start_index}"
                 seq_match = SequenceMatch(
                     unique_identifier=gene_symbol,
                     protein_name=gene_symbol,
+                    start_index=start_index,
                     match_location=match_location,
                 )
                 matches[sequence].append(seq_match)

--- a/src/xlranker/util/readers.py
+++ b/src/xlranker/util/readers.py
@@ -1,6 +1,7 @@
 """Functions for reading data files, mapping files, and networks."""
 
 import logging
+import re
 from pathlib import Path
 
 import polars as pl
@@ -11,6 +12,21 @@ from xlranker.config import config
 from xlranker.util import get_pair_id
 
 logger = logging.getLogger(__name__)
+
+
+def parse_linkage(link: str) -> int | None:
+    """Parse a link from a linkage string by removing all non-numeric chars.
+
+    Args:
+        link (str): the original linkage string
+
+    Returns:
+        int | None: 1-based index of the link or None if unable to parse
+    """
+    cleaned_link = re.sub("[^0-9]", "", link)
+    if len(cleaned_link) > 0:
+        return int(cleaned_link)
+    return None
 
 
 def read_data_matrix(
@@ -104,14 +120,16 @@ def read_data_folder(
     return ret_dict
 
 
-def read_network_file(network_path: str) -> dict[str, PeptidePair]:
+def read_network_file(network_path: str) -> tuple[dict[str, PeptidePair], bool]:
     """Reads TSV network file to a list of PeptideGroup.
 
     Args:
         network_path (str): path to the TSV file
 
     Returns:
-        list[PeptideGroup]: list of PeptideGroup representing the network
+        tuple[list[PeptideGroup], bool]: tuple with first element
+            is list of PeptideGroup representing the network
+            the bool is True if linkage information is present
 
     Raises:
         IndexError: Raised if there are not 2 columns in the network.
@@ -123,17 +141,33 @@ def read_network_file(network_path: str) -> dict[str, PeptidePair]:
             text = r.read().split("\n")
         new_rows = set()  # Track unique rows
         valid_rows = 0  # Keeps track of number of edges in original file
+        has_linkages = False
         for row in text:
             if "\t" in row:
                 valid_rows += 1
                 vals = row.split("\t")
-                val_a = vals[0]
-                val_b = vals[1]
-                if val_a > val_b:  # Make sure edges are all sorted the same.
-                    temp = val_a
-                    val_a = val_b
-                    val_b = temp
-                new_rows.add(f"{val_a}\t{val_b}")
+                if len(vals) == 2:
+                    val_a = vals[0]
+                    val_b = vals[1]
+                    if val_a > val_b:  # Make sure edges are all sorted the same.
+                        val_a, val_b = val_b, val_a
+                    new_rows.add(f"{val_a}\t{val_b}")
+                elif len(vals) == 4:
+                    has_linkages = True
+                    val_a = vals[0]
+                    link_a = vals[1]
+                    val_b = vals[2]
+                    link_b = vals[3]
+                    if val_a > val_b:  # Make sure edges are all sorted the same.
+                        val_a, val_b = val_b, val_a
+                        link_a, link_b = link_b, link_a
+                    new_rows.add(f"{val_a}\t{val_b}\t{link_a}\t{link_b}")
+                else:
+                    raise ValueError(
+                        """Network must contain either 2 or 4 columns.
+                        See documentation for details."""
+                    )
+
     except IndexError as e:
         logger.error("Index out of bound. Make sure network is in the correct format.")
         raise IndexError() from e
@@ -148,11 +182,16 @@ def read_network_file(network_path: str) -> dict[str, PeptidePair]:
     network: dict[str, PeptidePair] = {}
     for row in new_rows:
         vals = row.split("\t")
-        a = Peptide(vals[0])
-        b = Peptide(vals[1])
+        link_a = None
+        link_b = None
+        if has_linkages:
+            link_a = parse_linkage(vals[2])
+            link_b = parse_linkage(vals[3])
+        a = Peptide(vals[0], linkage=link_a)
+        b = Peptide(vals[1], linkage=link_b)
         group = PeptidePair(a, b)
         network[get_pair_id(a, b)] = group
-    return network
+    return (network, has_linkages)
 
 
 def read_mapping_table_file(file_path: str) -> dict[str, list[str]]:

--- a/tests/test_fasta_mapping.py
+++ b/tests/test_fasta_mapping.py
@@ -64,3 +64,23 @@ def test_custom_table(tmp_path):
         "OR4F16",
     ]
     assert res.peptide_to_protein["PLLALPPQGPPG"] == ["SAMD11"]
+
+
+def test_map_fasta_with_loc(tmp_path):
+    """Tests fasta mapping with location information."""
+    temp_file = tmp_path / "fasta_snippet.fa"
+    temp_file.write_text(FASTA_SNIPPET)
+    mapper = xlranker.util.mapping.PeptideMapper(
+        mapping_table_path=str(temp_file),
+        is_fasta=True,
+        split_index=6,
+        fasta_type=xlranker.util.mapping.FastaType.GENCODE,
+    )
+    sequences = ["LHYTTIM"]
+    res = mapper.map_fasta_with_loc(sequences)
+    matches = res.peptide_to_protein["LHYTTIM"]
+    assert len(matches) == 1
+    match = matches[0]
+    assert match.protein_name == "OR4F5"
+    assert match.start_index == 144
+    assert match.match_location == "L144"

--- a/tests/test_protein.py
+++ b/tests/test_protein.py
@@ -66,3 +66,16 @@ def test_protein_order_no_nulls():
         SMALL_PROTEIN,
         same_val_as_small,
     )
+
+
+def test_protein_linkages():
+    """Test that linkages can be added to proteins and are represented in string."""
+    protein = xlr.bio.Protein(name="Linky", unique_identifier="Linky")
+    assert str(protein) == "Linky"
+    protein.add_linkage("K10")
+    assert str(protein) == "Linky:K10"
+    protein.add_linkage("K20")
+    assert str(protein) == "Linky:K10,K20"
+    # Test uniqueness
+    protein.add_linkage("K10")
+    assert str(protein) == "Linky:K10,K20"


### PR DESCRIPTION
Adds information about protein linkages

## Input Format

To add information about the peptide linkage, add a column after each sequence with the 1-based index of the linkage.

xlranker will detect whether there is 4 or 2 columns. For 2 columns, it will run without adding linkage information. Otherwise, it will create additional networks and mapping tables that will include the linkage information.